### PR TITLE
Correct version of cmark pod is 0.21.0 (https://cocoapods.org/pods/cm…

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -2,4 +2,4 @@ platform :osx, 10.9
 
 use_frameworks!
 
-pod 'cmark', 0.21
+pod 'cmark', '0.21.0'


### PR DESCRIPTION
…ark).

Hi @chriseidhof , 

After checking out the repo and trying to do 'pod install' to install the cmark pod the following error comes up: 

```
Analyzing dependencies
[!] Unable to satisfy the following requirements:

- `cmark (= 0.21)` required by `Podfile`
```

So I looked into the Podfile and noticed that the pod version was wrong. This pull request fixes that :) 

Cheers, 
