### PR TITLE
adjust upstream link to new home

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # commonmark-swift
 
-A Swift wrapper around [cmark](http://github.com/jgm/cmark/).
+A Swift wrapper around [cmark](http://github.com/commonmark/cmark/).
 
 Originally written by Chris Eidhof, with contributions by Ole Begemann.
 


### PR DESCRIPTION
The redirect at https://github.com/jgm/cmark.git has changed to point to a CommonMark with GFM repo — this was in error, I believe. This PR makes the situation less confusing as it points the link in the README directly to the intended upstream, rather than going via (now mistaken) redirect.